### PR TITLE
Add retired version support

### DIFF
--- a/archive_cli.py
+++ b/archive_cli.py
@@ -94,7 +94,7 @@ def replace_links(filepath, version_name, version_displayname):
         updated_html.write(html_str)
 
 
-def preserve(version_name, version_displayname, changelog):
+def preserve(version_name, version_displayname, changelog, cti_url, gh_pages_url, retired):
     """preserve the current version on github as a named previous version. """
 
     print("preserving current version under route '" + version_name + \
@@ -182,7 +182,10 @@ def preserve(version_name, version_displayname, changelog):
         "path": version_name,
         "date_start": version_displayname["start"],
         "date_end": version_displayname["end"],
-        "changelog": changelog
+        "changelog": changelog,
+        "cti_url": cti_url,
+        "gh_pages_url": gh_pages_url,
+        "retired": retired
     })
     with open("archives.json", "w") as archives:
         archives.write(json.dumps(archives_data, indent=4))
@@ -200,8 +203,17 @@ if __name__ == "__main__":
                         help="the date the current version is being replaced in 'Month day, YEAR' format, e.g 'January 1, 1970'"
     )
     parser.add_argument("changelog", type=str,
-                        help="the name of the changelog file for this version, to be found in resources/updates. Typically updates-MONTH-YEAR, e.g 'updates-january-1970'"
+                        help="The name of the changelog file for this version, to be found in resources/updates. Typically updates-MONTH-YEAR, e.g 'updates-january-1970'"
+    )
+    parser.add_argument("cti_url", type=str,
+                        help="The mitre/cti url for this version, which is listed at https://github.com/mitre/cti/releases"
+    )
+    parser.add_argument("gh_pages_url", type=str,
+                        help="The url to the latest github commit for this version, found at https://github.com/mitre-attack/attack-website/commits/master"
+    )
+    parser.add_argument("retired", type=bool,
+                        help="The boolean value describing the status for this version. If true, this version will not be deployed to the att&ck website, and the entry for this version on /resources/previous-versions/ will be replaced with a blurb explaining that the version was retired, along with a descriptive link to cti_url and gh_pages_url"
     )
 
     args = parser.parse_args()
-    preserve(args.route, {"start": args.date_start, "end": args.date_end}, args.changelog)
+    preserve(args.route, {"start": args.date_start, "end": args.date_end}, args.changelog, args.cti_url, args.gh_pages_url, args.retired)

--- a/archives.json
+++ b/archives.json
@@ -3,18 +3,27 @@
         "path": "october2018",
         "date_start": "October 23, 2018",
         "date_end": "April 30, 2019",
-        "changelog": "updates-october-2018"
+        "changelog": "updates-october-2018",
+        "cti_url": "https://github.com/mitre/cti/releases/tag/ATT%26CK-v6.0",
+        "gh_pages_url": "https://github.com/mitre-attack/attack-website/tree/ece518a3467170065002a6a3785c8e94dbd7311b",
+        "retired": "false"
     },
     {
         "path": "april2019",
         "date_start": "May 1, 2019",
         "date_end": "July 31, 2019",
-        "changelog": "updates-april-2019"
+        "changelog": "updates-april-2019",
+        "cti_url": "https://github.com/mitre/cti/releases/tag/ATT%26CK-v4.0",
+        "gh_pages_url": "https://github.com/mitre-attack/attack-website/tree/68692a59429a201865bf5181612fe80b663dcd58",
+        "retired": "false"
     },
     {
         "path": "july2019",
         "date_start": "August 1, 2019",
         "date_end": "October 24, 2019",
-        "changelog": "updates-july-2019"
+        "changelog": "updates-july-2019",
+        "cti_url": "https://github.com/mitre/cti/releases/tag/ATT%26CK-v5.0",
+        "gh_pages_url": "https://github.com/mitre-attack/attack-website/tree/61008763a54650c281922c410ca66e638ba0451d",
+        "retired": "false"
     }
 ]


### PR DESCRIPTION
To support retired ATT&CK Website versions, new fields were added for each entry in archives.json, and new parser parameters were added to archive_cli.py.